### PR TITLE
Bugfix/#2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,16 @@ release: $(LIBNAME) libnvmmallocnoflush.so libnvmmallocnofence.so libnvmmallocno
 debug: $(LIBNAME)
 
 $(LIBNAME): ulib-svn/lib/libulib.a $(addprefix $(OBJDIR)/, $(OBJECTS))
-	$(CC) $(CFLAGS) -shared -o $@ $(LDFLAGS) $(addprefix $(OBJDIR)/, $(OBJECTS)) ulib-svn/lib/libulib.a
+	$(CC) $(CFLAGS) -shared -o $@ $(addprefix $(OBJDIR)/, $(OBJECTS)) ulib-svn/lib/libulib.a $(LDFLAGS)
 
 libnvmmallocnoflush.so: $(SRCDIR)/*.c ulib-svn/lib/libulib.a
-	$(CC) $(CFLAGS) -shared -o $@ $(LDFLAGS) -DNOFLUSH $+ ulib-svn/lib/libulib.a
+	$(CC) $(CFLAGS) -shared -o $@ -DNOFLUSH $+ ulib-svn/lib/libulib.a $(LDFLAGS)
 
 libnvmmallocnofence.so: $(SRCDIR)/*.c ulib-svn/lib/libulib.a
-	$(CC) $(CFLAGS) -shared -o $@ $(LDFLAGS) -DNOFENCE $+ ulib-svn/lib/libulib.a
+	$(CC) $(CFLAGS) -shared -o $@ -DNOFENCE $+ ulib-svn/lib/libulib.a $(LDFLAGS)
 
 libnvmmallocnone.so: $(SRCDIR)/*.c ulib-svn/lib/libulib.a
-	$(CC) $(CFLAGS) -shared -o $@ $(LDFLAGS) -DNOFLUSH -DNOFENCE $+ ulib-svn/lib/libulib.a
+	$(CC) $(CFLAGS) -shared -o $@ -DNOFLUSH -DNOFENCE $+ ulib-svn/lib/libulib.a $(LDFLAGS)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c $(SRCDIR)/*.h
 	@mkdir -p $(OBJDIR)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ulib-svn/lib/libulib.a:
 	cd ulib-svn; make release
 
 clean:
-	@rm -f $(LIBNAME)
+	@rm -f $(LIBNAME) libnvmmallocnoflush.so libnvmmallocnofence.so libnvmmallocnone.so
 	@rm -rf $(OBJDIR)
 
 .PHONY: test debug release

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -1,5 +1,5 @@
 CXX ?= g++
-CXXFLAGS := -std=c++11 -Wall -Isrc -I../src
+CXXFLAGS := -std=c++11 -Wall -Isrc -I../src -pthread
 debug:   CXXFLAGS += -O0 -ggdb
 release: CXXFLAGS += -O3
 LDFLAGS := -L.. -lpthread -ltbb -lnvmmalloc
@@ -15,17 +15,17 @@ debug: $(TARGETS)
 
 $(BUILDDIR)/bench_recovery: $(SRCDIR)/bench_recovery.cpp $(SRCDIR)/common.h $(SRCDIR)/common.cpp
 	@mkdir -p $(BUILDDIR)
-	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@ $(LDFLAGS) $< $(SRCDIR)/common.cpp
+	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@ $< $(SRCDIR)/common.cpp $(LDFLAGS)
 
 $(BUILDDIR)/%: $(SRCDIR)/%.cpp $(SRCDIR)/common.h $(SRCDIR)/common.cpp
 	@mkdir -p $(BUILDDIR)
-	$(CXX) $(CXXFLAGS) -DUSE_MALLOC -o $@ $(LDFLAGS) $< $(SRCDIR)/common.cpp
-	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm $(LDFLAGS) $< $(SRCDIR)/common.cpp
+	$(CXX) $(CXXFLAGS) -DUSE_MALLOC -o $@ $< $(SRCDIR)/common.cpp $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm $< $(SRCDIR)/common.cpp $(LDFLAGS)
 	#$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -DHAS_CLFLUSHOPT -o $@_nvm_clflushopt $(LDFLAGS) $< $(SRCDIR)/common.cpp
 	#$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -DHAS_CLWB -o $@_nvm_clwb $(LDFLAGS) $< $(SRCDIR)/common.cpp
-	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm_noflush $(LDFLAGS)noflush $< $(SRCDIR)/common.cpp
-	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm_nofence $(LDFLAGS)nofence $< $(SRCDIR)/common.cpp
-	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm_none $(LDFLAGS)none $< $(SRCDIR)/common.cpp
+	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm_noflush $< $(SRCDIR)/common.cpp $(LDFLAGS)noflush
+	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm_nofence $< $(SRCDIR)/common.cpp $(LDFLAGS)nofence
+	$(CXX) $(CXXFLAGS) -DUSE_NVM_MALLOC -o $@_nvm_none $< $(SRCDIR)/common.cpp $(LDFLAGS)none
 
 clean:
 	@rm -rf $(BUILDDIR)

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -29,6 +29,7 @@ inline void error_and_exit(char *msg, ...) {
     va_end(args);
     exit(-1);
 }
+void error_and_exit(char *msg, ...);
 
 static void            *chunk_region_start = NULL;
        void            *meta_info = NULL; /* must be non-static as it is exported to other translation units */


### PR DESCRIPTION
This fixes the build issues on Ubuntu 16.04 with gcc/g++ 5.4 and removes all built libraries on `make clean`.
